### PR TITLE
Fix Xcode 9 compile errors.

### DIFF
--- a/core/ofx.h
+++ b/core/ofx.h
@@ -28,7 +28,7 @@
 #include <memory>
 
 #include "fixed.h"
-#include "DateTime.h"
+#include "datetime.h"
 #include "document.h"
 
 enum OFX_TYPE

--- a/mac/TransactionsController.mm
+++ b/mac/TransactionsController.mm
@@ -29,6 +29,7 @@
 #import "SplitViewEx.h"
 #import "IndexItem.h"
 #import "ValueFormatter.h"
+#import "TransactionItem.h"
 
 @implementation TransactionsController
 
@@ -1252,7 +1253,7 @@ static TransactionsController *gSharedInterface = nil;
 		{
 			[item setValue:object forKey:identifier];
 			
-			int nTrans = [item transaction];
+			int nTrans = [(TransactionItem *)item transaction];
 			
 			Transaction *trans = NULL;
 			


### PR DESCRIPTION
Xcode 9 fails building on these.